### PR TITLE
Handle AI response markdown

### DIFF
--- a/src/components/ParserModal.jsx
+++ b/src/components/ParserModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { X, Brain, Loader, AlertCircle, CheckCircle } from 'lucide-react';
+import parseAIResponse from '../utils/aiResponseFormatter';
 
 function ParserModal({ isOpen, onClose, onComplete, courses }) {
   const [inputText, setInputText] = useState('');
@@ -165,7 +166,7 @@ function ParserModal({ isOpen, onClose, onComplete, courses }) {
       });
       
       const content = data.choices[0].message.content;
-      const parsed = JSON.parse(content);
+      const parsed = parseAIResponse(content);
       console.log('[Parser] Studiora extracted assignments:', parsed);
       
       updateProgress('ai', `Studiora found ${parsed.assignments?.length || 0} assignments (Cost: $${actualCost.toFixed(4)})`);

--- a/src/utils/aiResponseFormatter.js
+++ b/src/utils/aiResponseFormatter.js
@@ -1,0 +1,49 @@
+/**
+ * Utility to parse JSON from AI responses that may include Markdown code blocks.
+ * Removes markdown formatting and extracts the JSON portion before parsing.
+ */
+
+/**
+ * Strip Markdown code fences and trim whitespace.
+ * @param {string} text
+ * @returns {string}
+ */
+export function stripMarkdown(text = '') {
+  return text
+    .replace(/```(?:json)?/gi, '') // remove ```json or ```JSON
+    .replace(/```/g, '') // remove remaining ```
+    .trim();
+}
+
+/**
+ * Parse JSON from a possibly markdown-formatted string.
+ * @param {string} content
+ * @returns {object}
+ */
+export default function parseAIResponse(content) {
+  const cleaned = stripMarkdown(content);
+
+  // Find first opening brace or bracket
+  const firstObj = cleaned.indexOf('{');
+  const firstArr = cleaned.indexOf('[');
+  let start = -1;
+  if (firstObj !== -1 && firstArr !== -1) {
+    start = Math.min(firstObj, firstArr);
+  } else {
+    start = firstObj !== -1 ? firstObj : firstArr;
+  }
+  if (start === -1) {
+    throw new Error('No JSON found in AI response');
+  }
+
+  // Slice to just the JSON portion
+  let jsonString = cleaned.slice(start);
+  const endObj = jsonString.lastIndexOf('}');
+  const endArr = jsonString.lastIndexOf(']');
+  const end = Math.max(endObj, endArr);
+  if (end !== -1) {
+    jsonString = jsonString.slice(0, end + 1);
+  }
+
+  return JSON.parse(jsonString);
+}


### PR DESCRIPTION
## Summary
- add helper for parsing AI responses that strips markdown code fences
- use helper in ParserModal when parsing responses from Studiora AI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c2783d400832cb75c50fa4163face