### PR TITLE
Switch parser to OpenAI responses API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fullcalendar/timegrid": "^6.1.15",
         "date-fns": "^3.6.0",
         "lucide-react": "^0.263.1",
+        "openai": "^5.8.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1475,6 +1476,27 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/openai": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.8.2.tgz",
+      "integrity": "sha512-8C+nzoHYgyYOXhHGN6r0fcb4SznuEn1R7YZMvlqDbnCuE0FM2mm3T1HiYW6WIcMS/F1Of2up/cSPjLPaWt0X9Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fullcalendar/timegrid": "^6.1.15",
     "date-fns": "^3.6.0",
     "lucide-react": "^0.263.1",
+    "openai": "^5.8.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },


### PR DESCRIPTION
## Summary
- install `openai` dependency
- drop regex-based parser logic
- use OpenAI prompt `pmpt_6867fd7d55408195837431a01c6d01aa0df59ec7a5e95a0b` for parsing
- simplify parsing workflow in `ParserModal`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68683dc2d99c832cba477e87fdde289d